### PR TITLE
#152106730 Validate Date Entered When Incident Occurred

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,84 +1,103 @@
-const express = require('express');
-const http = require('http');
-const bodyParser = require('body-parser');
-const slackInteractiveMessages = require('@slack/interactive-messages');
-const { createSlackEventAdapter } = require('@slack/events-api');
-const SlackClient = require('@slack/client').WebClient;
+const express = require("express");
+const http = require("http");
+const bodyParser = require("body-parser");
+const slackInteractiveMessages = require("@slack/interactive-messages");
+const { createSlackEventAdapter } = require("@slack/events-api");
+const SlackClient = require("@slack/client").WebClient;
 
-const  { initiationMessage, categoryMessage, witnessesMessage, getConfirmationMessage } = require('./modules/messages'); 
-const actions = require('./modules/actions');
+const {
+  isDateValid,
+  isDateFuture
+} = require("./modules/validation/date_validation");
 
-const dotenv = require('dotenv');
+const {
+  initiationMessage,
+  categoryMessage,
+  witnessesMessage,
+  getConfirmationMessage
+} = require("./modules/messages");
+const actions = require("./modules/actions");
+
+const dotenv = require("dotenv");
 
 dotenv.load();
 
-const slackEvents = createSlackEventAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackEvents = createSlackEventAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const sc = new SlackClient(process.env.SLACK_BOT_TOKEN);
-const slackMessages = slackInteractiveMessages
-  .createMessageAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackMessages = slackInteractiveMessages.createMessageAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const port = process.env.PORT || 3000;
 
 const confirmIncident = (user, channel) => {
   const data = actions.tempIncidents[user];
-  sc.chat.postMessage(
-    channel,
-    '',
-    getConfirmationMessage(data),
-  (err, res) => {
+  sc.chat.postMessage(channel, "", getConfirmationMessage(data), (err, res) => {
     // console.log(res);
   });
-}
+};
 
-slackEvents.on('message', (event) => {
+slackEvents.on("message", event => {
   // do not respond to edited messages or messages from me
-  if (event.subtype === 'bot_message' || event.subtype === 'message_changed') {
+  if (event.subtype === "bot_message" || event.subtype === "message_changed") {
     return;
-  };
+  }
 
   const userId = event.user;
   if (!actions.tempIncidents[userId]) {
-
-    sc.chat.postMessage(
-      event.channel,
-      '',
-      initiationMessage,
-    (err, res) => {
+    sc.chat.postMessage(event.channel, "", initiationMessage, (err, res) => {
       // console.log(res);
     });
-
   } else {
-
     const currentStep = actions.tempIncidents[userId].step;
-    switch(currentStep) {
+    switch (currentStep) {
       case 0:
+        if (isDateValid(event.text) === false) {
+          sc.chat.postMessage(
+            event.channel,
+            "You cannot report a future incident or Invalid date entered (dd-mm-yy)",
+            (err, res) => {
+              // console.log(res);
+            }
+          );
+
+          break;
+        }
+
+        if (isDateFuture(event.text) === true) {
+          sc.chat.postMessage(
+            event.channel,
+            "You cannot report a future incident or Invalid date entered (dd-mm-yy)",
+            (err, res) => {
+              // console.log(res);
+            }
+          );
+
+          break;
+        }
+
         actions.saveDate(event);
         sc.chat.postMessage(
           event.channel,
-          'Where did this happen? (place, city, country)',
-        (err, res) => {
-          // console.log(res);
-        });
+          "Where did this happen? (place, city, country)",
+          (err, res) => {
+            // console.log(res);
+          }
+        );
         break;
       case 1:
         actions.saveLocation(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          categoryMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", categoryMessage, (err, res) => {
           // console.log(res);
         });
         break;
       case 2:
-        console.log('Logic flaw??');
+        console.log("Logic flaw??");
         break;
       case 3:
         actions.saveDescription(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          witnessesMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", witnessesMessage, (err, res) => {
           // console.log(res);
         });
         break;
@@ -87,59 +106,56 @@ slackEvents.on('message', (event) => {
         confirmIncident(event.user, event.channel);
         break;
       case 5:
-       
         break;
-
     }
   }
-
 });
 
-slackMessages.action('report', (payload, respond)=> {
+slackMessages.action("report", (payload, respond) => {
   actions.start(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('category', (payload, respond)=> {
+slackMessages.action("category", (payload, respond) => {
   actions.saveCategory(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('confirm', (payload, respond)=> {
+slackMessages.action("confirm", (payload, respond) => {
   actions.saveIncident(payload, respond);
   return {
-    text: 'Your incident has been logged'
+    text: "Your incident has been logged"
   };
 });
 
-slackMessages.action('witnesses', (payload, respond)=> {
+slackMessages.action("witnesses", (payload, respond) => {
   const selected = payload.actions[0].value;
-  if (selected === 'no') {
+  if (selected === "no") {
     // show confirmation
     const event = {
       user: payload.user.id,
-      text: ''
-    }
+      text: ""
+    };
     actions.saveWitnesses(event);
     confirmIncident(payload.user.id, payload.channel.id);
   } else {
-    respond({'text': 'Who are your witnesses? (@witness1, @witness2)'});
+    respond({ text: "Who are your witnesses? (@witness1, @witness2)" });
   }
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
 // Start a basic HTTP server
 const app = express();
 app.use(bodyParser.json());
-app.use('/slack/events', slackEvents.expressMiddleware());
+app.use("/slack/events", slackEvents.expressMiddleware());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use('/slack/actions', slackMessages.expressMiddleware());
+app.use("/slack/actions", slackMessages.expressMiddleware());
 // Start the server
 http.createServer(app).listen(port, () => {
   console.log(`server listening on port ${port}`);

--- a/modules/validation/date_validation.js
+++ b/modules/validation/date_validation.js
@@ -1,0 +1,29 @@
+const isDateValid = entered_date => {
+  return /((0[1-9]|[12]\d|3[01])-(0[1-9]|1[0-2])-(\d\d))/.test(entered_date);
+};
+
+const isDateFuture = entered_date => {
+  entered_date_as_array = entered_date.split("-");
+
+  date_starting_with_month =
+    entered_date_as_array[1] +
+    "-" +
+    entered_date_as_array[0] +
+    "-" +
+    entered_date_as_array[2];
+
+  formatted_entered_date = new Date(date_starting_with_month);
+
+  date_today = new Date();
+
+  if (formatted_entered_date > date_today) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+module.exports = {
+  isDateValid,
+  isDateFuture
+};


### PR DESCRIPTION
#### What does this PR do?
This PR validates the date entered on Slack, bot-side, of when an incident occurred

#### Description of Task to be completed?
- When a user enters a date, the bot should ask them to repeat if it does not follow the format dd-mm-yy
- When a user enters a date, the bot asks them to repeat if it is a future date

#### How should this be manually tested?
Given that you are signed in to a Slack workspace where the bot has been installed:
- Initiate a conversation with the bot
- Select that you want to report an incident
- The bot will prompt you to enter when the incident occurred
- Type in a date
- If the date is invalid or in the future, the bot will prompt you to enter the date again

#### Any background context you want to add?
This will help prevent invalid dates and typos of when an incident occurred when a user is reporting an incident

#### Screenshots
![kapture 2017-12-04 at 12 56 29](https://user-images.githubusercontent.com/6702127/33546631-96dd7034-d8f2-11e7-8425-b9784094d6ee.gif)


#### What are the relevant pivotal tracker stories?
[#152106730](https://www.pivotaltracker.com/n/projects/2117172/stories/152106730)
