### PR TITLE
#152106778 Validate Location of Incident Entered

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,84 +1,88 @@
-const express = require('express');
-const http = require('http');
-const bodyParser = require('body-parser');
-const slackInteractiveMessages = require('@slack/interactive-messages');
-const { createSlackEventAdapter } = require('@slack/events-api');
-const SlackClient = require('@slack/client').WebClient;
+const express = require("express");
+const http = require("http");
+const bodyParser = require("body-parser");
+const slackInteractiveMessages = require("@slack/interactive-messages");
+const { createSlackEventAdapter } = require("@slack/events-api");
+const SlackClient = require("@slack/client").WebClient;
 
-const  { initiationMessage, categoryMessage, witnessesMessage, getConfirmationMessage } = require('./modules/messages'); 
-const actions = require('./modules/actions');
+const { isLocationValid } = require("./modules/validation/location_validation");
 
-const dotenv = require('dotenv');
+const {
+  initiationMessage,
+  categoryMessage,
+  witnessesMessage,
+  getConfirmationMessage
+} = require("./modules/messages");
+const actions = require("./modules/actions");
+
+const dotenv = require("dotenv");
 
 dotenv.load();
 
-const slackEvents = createSlackEventAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackEvents = createSlackEventAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const sc = new SlackClient(process.env.SLACK_BOT_TOKEN);
-const slackMessages = slackInteractiveMessages
-  .createMessageAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackMessages = slackInteractiveMessages.createMessageAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const port = process.env.PORT || 3000;
 
 const confirmIncident = (user, channel) => {
   const data = actions.tempIncidents[user];
-  sc.chat.postMessage(
-    channel,
-    '',
-    getConfirmationMessage(data),
-  (err, res) => {
+  sc.chat.postMessage(channel, "", getConfirmationMessage(data), (err, res) => {
     // console.log(res);
   });
-}
+};
 
-slackEvents.on('message', (event) => {
+slackEvents.on("message", event => {
   // do not respond to edited messages or messages from me
-  if (event.subtype === 'bot_message' || event.subtype === 'message_changed') {
+  if (event.subtype === "bot_message" || event.subtype === "message_changed") {
     return;
-  };
+  }
 
   const userId = event.user;
   if (!actions.tempIncidents[userId]) {
-
-    sc.chat.postMessage(
-      event.channel,
-      '',
-      initiationMessage,
-    (err, res) => {
+    sc.chat.postMessage(event.channel, "", initiationMessage, (err, res) => {
       // console.log(res);
     });
-
   } else {
-
     const currentStep = actions.tempIncidents[userId].step;
-    switch(currentStep) {
+    switch (currentStep) {
       case 0:
         actions.saveDate(event);
         sc.chat.postMessage(
           event.channel,
-          'Where did this happen? (place, city, country)',
-        (err, res) => {
-          // console.log(res);
-        });
+          "Where did this happen? (place, city, country)",
+          (err, res) => {
+            // console.log(res);
+          }
+        );
         break;
       case 1:
+        if (isLocationValid(event.text) === false) {
+          sc.chat.postMessage(
+            event.channel,
+            "The location should at minimum be in the format 'place, city, country'",
+            (err, res) => {
+              // console.log(res);
+            }
+          );
+
+          break;
+        }
+
         actions.saveLocation(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          categoryMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", categoryMessage, (err, res) => {
           // console.log(res);
         });
         break;
       case 2:
-        console.log('Logic flaw??');
+        console.log("Logic flaw??");
         break;
       case 3:
         actions.saveDescription(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          witnessesMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", witnessesMessage, (err, res) => {
           // console.log(res);
         });
         break;
@@ -87,59 +91,56 @@ slackEvents.on('message', (event) => {
         confirmIncident(event.user, event.channel);
         break;
       case 5:
-       
         break;
-
     }
   }
-
 });
 
-slackMessages.action('report', (payload, respond)=> {
+slackMessages.action("report", (payload, respond) => {
   actions.start(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('category', (payload, respond)=> {
+slackMessages.action("category", (payload, respond) => {
   actions.saveCategory(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('confirm', (payload, respond)=> {
+slackMessages.action("confirm", (payload, respond) => {
   actions.saveIncident(payload, respond);
   return {
-    text: 'Your incident has been logged'
+    text: "Your incident has been logged"
   };
 });
 
-slackMessages.action('witnesses', (payload, respond)=> {
+slackMessages.action("witnesses", (payload, respond) => {
   const selected = payload.actions[0].value;
-  if (selected === 'no') {
+  if (selected === "no") {
     // show confirmation
     const event = {
       user: payload.user.id,
-      text: ''
-    }
+      text: ""
+    };
     actions.saveWitnesses(event);
     confirmIncident(payload.user.id, payload.channel.id);
   } else {
-    respond({'text': 'Who are your witnesses? (@witness1, @witness2)'});
+    respond({ text: "Who are your witnesses? (@witness1, @witness2)" });
   }
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
 // Start a basic HTTP server
 const app = express();
 app.use(bodyParser.json());
-app.use('/slack/events', slackEvents.expressMiddleware());
+app.use("/slack/events", slackEvents.expressMiddleware());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use('/slack/actions', slackMessages.expressMiddleware());
+app.use("/slack/actions", slackMessages.expressMiddleware());
 // Start the server
 http.createServer(app).listen(port, () => {
   console.log(`server listening on port ${port}`);

--- a/modules/validation/location_validation.js
+++ b/modules/validation/location_validation.js
@@ -1,0 +1,23 @@
+const isLocationValid = entered_location => {
+  entered_location = entered_location.split(",");
+
+  if (entered_location.length < 3) {
+    return false;
+  } else {
+    return true;
+  }
+
+  entered_location.forEach(location => {
+    location = location.trim();
+
+    if (/^[\w'\-]*/.test(location) === false) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+};
+
+module.exports = {
+  isLocationValid
+};


### PR DESCRIPTION
#### What does this PR do?
This PR validates the `location` entered where an incident occurred on Slack, bot-side

#### Description of Task to be completed?
- When a user enters a `location` where the incident being reported took place, the bot should ask them to repeat if `at minimum` it doesn't meet the format `'place, city, country'`

#### How should this be manually tested?
Given that you are signed in to a Slack workspace where the bot has been installed:
- Initiate a conversation with the bot
- Respond to the bot's initial prompts, up until it prompts you for the location where the incident occurred
- Type in a location, ensuring it meets the format `'place, city, country'`
- If the typed in location doesn't meet the aforementioned format, the bot will prompt you to enter the location again

#### Any background context you want to add?
This will help gather a clear understanding of where the incident being reported took place

#### Screenshots
![kapture 2017-11-30 at 13 43 18](https://user-images.githubusercontent.com/6702127/33426895-74e3826e-d5d4-11e7-9102-d758ebee427e.gif)

#### What are the relevant pivotal tracker stories?
[#152106778](https://www.pivotaltracker.com/n/projects/2117172/stories/152106778)
