### PR TITLE
#152106921 Validate Witnesses to An Incident Entered

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,145 +1,146 @@
-const express = require('express');
-const http = require('http');
-const bodyParser = require('body-parser');
-const slackInteractiveMessages = require('@slack/interactive-messages');
-const { createSlackEventAdapter } = require('@slack/events-api');
-const SlackClient = require('@slack/client').WebClient;
+const express = require("express");
+const http = require("http");
+const bodyParser = require("body-parser");
+const slackInteractiveMessages = require("@slack/interactive-messages");
+const { createSlackEventAdapter } = require("@slack/events-api");
+const SlackClient = require("@slack/client").WebClient;
 
-const  { initiationMessage, categoryMessage, witnessesMessage, getConfirmationMessage } = require('./modules/messages'); 
-const actions = require('./modules/actions');
+const { isWitnessValid } = require("./modules/validation/witnesses_validation");
 
-const dotenv = require('dotenv');
+const {
+  initiationMessage,
+  categoryMessage,
+  witnessesMessage,
+  getConfirmationMessage
+} = require("./modules/messages");
+const actions = require("./modules/actions");
+
+const dotenv = require("dotenv");
 
 dotenv.load();
 
-const slackEvents = createSlackEventAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackEvents = createSlackEventAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const sc = new SlackClient(process.env.SLACK_BOT_TOKEN);
-const slackMessages = slackInteractiveMessages
-  .createMessageAdapter(process.env.SLACK_VERIFICATION_TOKEN);
+const slackMessages = slackInteractiveMessages.createMessageAdapter(
+  process.env.SLACK_VERIFICATION_TOKEN
+);
 const port = process.env.PORT || 3000;
 
 const confirmIncident = (user, channel) => {
   const data = actions.tempIncidents[user];
-  sc.chat.postMessage(
-    channel,
-    '',
-    getConfirmationMessage(data),
-  (err, res) => {
+  sc.chat.postMessage(channel, "", getConfirmationMessage(data), (err, res) => {
     // console.log(res);
   });
-}
+};
 
-slackEvents.on('message', (event) => {
+slackEvents.on("message", event => {
   // do not respond to edited messages or messages from me
-  if (event.subtype === 'bot_message' || event.subtype === 'message_changed') {
+  if (event.subtype === "bot_message" || event.subtype === "message_changed") {
     return;
-  };
+  }
 
   const userId = event.user;
   if (!actions.tempIncidents[userId]) {
-
-    sc.chat.postMessage(
-      event.channel,
-      '',
-      initiationMessage,
-    (err, res) => {
+    sc.chat.postMessage(event.channel, "", initiationMessage, (err, res) => {
       // console.log(res);
     });
-
   } else {
-
     const currentStep = actions.tempIncidents[userId].step;
-    switch(currentStep) {
+    switch (currentStep) {
       case 0:
         actions.saveDate(event);
         sc.chat.postMessage(
           event.channel,
-          'Where did this happen? (place, city, country)',
-        (err, res) => {
-          // console.log(res);
-        });
+          "Where did this happen? (place, city, country)",
+          (err, res) => {
+            // console.log(res);
+          }
+        );
         break;
       case 1:
         actions.saveLocation(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          categoryMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", categoryMessage, (err, res) => {
           // console.log(res);
         });
         break;
       case 2:
-        console.log('Logic flaw??');
+        console.log("Logic flaw??");
         break;
       case 3:
         actions.saveDescription(event);
-        sc.chat.postMessage(
-          event.channel,
-          '',
-          witnessesMessage,
-        (err, res) => {
+        sc.chat.postMessage(event.channel, "", witnessesMessage, (err, res) => {
           // console.log(res);
         });
         break;
       case 4:
+        if (isWitnessValid(event.text) === false) {
+          sc.chat.postMessage(
+            event.channel,
+            "Kindly ensure all witnesses' Slack handles are in valid format and correct",
+            (err, res) => {
+              // console.log(res);
+            }
+          );
+
+          break;
+        }
+
         actions.saveWitnesses(event);
         confirmIncident(event.user, event.channel);
         break;
       case 5:
-       
         break;
-
     }
   }
-
 });
 
-slackMessages.action('report', (payload, respond)=> {
+slackMessages.action("report", (payload, respond) => {
   actions.start(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('category', (payload, respond)=> {
+slackMessages.action("category", (payload, respond) => {
   actions.saveCategory(payload, respond);
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
-slackMessages.action('confirm', (payload, respond)=> {
+slackMessages.action("confirm", (payload, respond) => {
   actions.saveIncident(payload, respond);
   return {
-    text: 'Your incident has been logged'
+    text: "Your incident has been logged"
   };
 });
 
-slackMessages.action('witnesses', (payload, respond)=> {
+slackMessages.action("witnesses", (payload, respond) => {
   const selected = payload.actions[0].value;
-  if (selected === 'no') {
+  if (selected === "no") {
     // show confirmation
     const event = {
       user: payload.user.id,
-      text: ''
-    }
+      text: ""
+    };
     actions.saveWitnesses(event);
     confirmIncident(payload.user.id, payload.channel.id);
   } else {
-    respond({'text': 'Who are your witnesses? (@witness1, @witness2)'});
+    respond({ text: "Who are your witnesses? (@witness1, @witness2)" });
   }
   return {
-    text: 'Just a sec'
+    text: "Just a sec"
   };
 });
 
 // Start a basic HTTP server
 const app = express();
 app.use(bodyParser.json());
-app.use('/slack/events', slackEvents.expressMiddleware());
+app.use("/slack/events", slackEvents.expressMiddleware());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use('/slack/actions', slackMessages.expressMiddleware());
+app.use("/slack/actions", slackMessages.expressMiddleware());
 // Start the server
 http.createServer(app).listen(port, () => {
   console.log(`server listening on port ${port}`);

--- a/modules/validation/witnesses_validation.js
+++ b/modules/validation/witnesses_validation.js
@@ -1,0 +1,21 @@
+const isWitnessValid = entered_witnesses => {
+  entered_witnesses_array = entered_witnesses.split(",");
+
+  regex_test_result_array = [];
+
+  entered_witnesses_array.forEach(entered_witness => {
+    entered_witness = entered_witness.trim();
+
+    regex_test_result_array.push(/^<@[A-Z0-9]*>$/.test(entered_witness));
+  });
+
+  if (regex_test_result_array.includes(false) === true) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
+module.exports = {
+  isWitnessValid
+};


### PR DESCRIPTION
#### What does this PR do?
This PR validates the `witnesses` entered to an incident on Slack, bot-side

#### Description of Task to be completed?
- When a user enters a `witness` or `witnesses` to an incident, the bot should ask them to repeat if a witness' `Slack handle is non-existing` or a witness entered is in an `invalid format`

#### How should this be manually tested?
Given that you are signed in to a Slack workspace where the bot has been installed:
- Initiate a conversation with the bot
- Respond to the bot's initial prompts, up until it prompts you if there are witnesses to your incident
- Select `Yes` then type in the witnesses when prompted, ensuring it meets the format `@witness1, @witness2`
- If a witness' `Slack handle` is non-existent, the bot will prompt you to verify and enter the witnesses again
- If a witness is in an `invalid format`, the bot will prompt you to verify and enter the witnesses again

#### Any background context you want to add?
This will help prevent non-existing witnesses from being entered

#### Screenshots
![kapture 2017-12-04 at 9 18 34](https://user-images.githubusercontent.com/6702127/33538773-30ef9284-d8d4-11e7-8216-0746377d6db6.gif)

#### What are the relevant pivotal tracker stories?
[#152106921](https://www.pivotaltracker.com/n/projects/2117172/stories/152106921)
