### PR TITLE
#154437464 Capture Subject of Incident Entered

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,17 @@ slackEvents.on("message", event => {
     const currentStep = actions.tempIncidents[userId].step;
     switch (currentStep) {
       case 0:
+        actions.saveSubject(event);
+        sc.chat.postMessage(
+          event.channel,
+          "When did the incident occur? (dd-mm-yy)",
+          (err, res) => {
+            // console.log(res);
+          }
+        );
+
+        break;
+      case 1:
         if (isDateValid(event.text) === false) {
           sc.chat.postMessage(
             event.channel,
@@ -90,7 +101,7 @@ slackEvents.on("message", event => {
           }
         );
         break;
-      case 1:
+      case 2:
         if (isLocationValid(event.text) === false) {
           sc.chat.postMessage(
             event.channel,
@@ -108,10 +119,10 @@ slackEvents.on("message", event => {
           // console.log(res);
         });
         break;
-      case 2:
+      case 3:
         console.log("Logic flaw??");
         break;
-      case 3:
+      case 4:
         if (isDescriptionAdequate(event.text) === false) {
           sc.chat.postMessage(
             event.channel,
@@ -129,7 +140,7 @@ slackEvents.on("message", event => {
           // console.log(res);
         });
         break;
-      case 4:
+      case 5:
         if (isWitnessValid(event.text) === false) {
           sc.chat.postMessage(
             event.channel,
@@ -145,7 +156,7 @@ slackEvents.on("message", event => {
         actions.saveWitnesses(event);
         confirmIncident(event.user, event.channel);
         break;
-      case 5:
+      case 6:
         break;
     }
   }

--- a/modules/actions.js
+++ b/modules/actions.js
@@ -12,9 +12,18 @@ const start = (payload, respond) => {
     tempIncidents[userId] = {
       step: 0
     };
-    return respond({'text': "When did the incident occur? (dd-mm-yy)"});
+    return respond({'text': "What is the subject of the incident?"});
   }
   
+}
+
+const saveSubject = (event) => {
+  const userId = event.user;
+  const message = event.text;
+  tempIncidents[userId].step += 1;
+  //TODO: add subject validation 
+  tempIncidents[userId].subject = message;
+
 }
 
 const saveDate = (event) => {
@@ -67,6 +76,7 @@ const saveWitnesses = (event) => {
 module.exports = {
   start,
   tempIncidents,
+  saveSubject,
   saveDate,
   saveLocation,
   saveCategory,

--- a/modules/messages.js
+++ b/modules/messages.js
@@ -73,6 +73,11 @@ const getConfirmationMessage = (data) =>
        "callback_id": "confirm",
        "fields": [
            {
+              "title": "Subject",
+              "value": data.subject,
+              "short": false
+           },
+           {
                "title": "Category",
                "value": data.category,
                "short": false


### PR DESCRIPTION
#### What does this PR do?
This PR requests a user to enter an incident subject on Slack, bot-side

#### Description of Task to be completed?
- When a user indicates that they want to report an incident, the bot will request them to enter the subject of the incident.

#### How should this be manually tested?
Given that you are signed in to a Slack workspace where the bot has been installed:
- Initiate a conversation with the bot
- Indicate that you want to report an incident
- The bot will request you to enter the incident subject

#### Any background context you want to add?
This will help in giving an idea of what the incident is about as they'll contain a subject

#### Screenshots
![kapture 2018-01-22 at 15 03 42](https://user-images.githubusercontent.com/6702127/35219910-7b2868d0-ff85-11e7-85c0-152f3111ce8d.gif)

#### What are the relevant pivotal tracker stories?
[#152106921](https://www.pivotaltracker.com/n/projects/2117172/stories/154437464)
