### PR TITLE
#154518809 Validate Subject of an Incident Entered

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ const { isLocationValid } = require("./modules/validation/location_validation");
 const {
   isDescriptionAdequate
 } = require("./modules/validation/description_validation");
+const {
+  isSubjectAdequate
+} = require("./modules/validation/subject_validation");
 const { isWitnessValid } = require("./modules/validation/witnesses_validation");
 const {
   isDateValid,
@@ -57,6 +60,15 @@ slackEvents.on("message", event => {
     const currentStep = actions.tempIncidents[userId].step;
     switch (currentStep) {
       case 0:
+        if (!isSubjectAdequate(event.text)) {
+          sc.chat.postMessage(
+            event.channel,
+            "Kindly try to keep incident subject under 10 words",
+            (err, res) => {});
+
+          break;
+        }
+
         actions.saveSubject(event);
         sc.chat.postMessage(
           event.channel,

--- a/modules/validation/subject_validation.js
+++ b/modules/validation/subject_validation.js
@@ -1,0 +1,7 @@
+const isSubjectAdequate = entered_subject => {
+  return entered_subject.split(" ").length > 10;
+};
+
+module.exports = {
+  isSubjectAdequate
+};


### PR DESCRIPTION
#### What does this PR do?
This PR validates the subject of an incident entered on Slack, bot-side

#### Description of Task to be completed?
- When a user enters the `subject` of an incident, the bot should ask them to repeat if the `subject` is more than `10 words`

#### How should this be manually tested?
Given that you are signed in to a Slack workspace where the bot has been installed:
- Initiate a conversation with the bot
- Indicate that you want to report an incident
- Enter a `subject` that's more than 10 words long
- The bot should request you to try and keep the subject to less than 10 words long

#### Any background context you want to add?
This will help keep the subject brief and to the point, as it represents a summary of the incident being reported

#### Screenshots
![kapture 2018-01-22 at 18 24 14](https://user-images.githubusercontent.com/6702127/35228323-7b35f5e2-ffa1-11e7-80fe-7d4f47ed8c7e.gif)


#### What are the relevant pivotal tracker stories?
[#152106921](https://www.pivotaltracker.com/n/projects/2117172/stories/154518809)
