### PR TITLE
Chore: setup docker for wire-bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+README.md
+Procfile
+.vscode/
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+#Create our image from Node alpine
+FROM node:alpine
+
+LABEL maintainer "Vicky<victoria.aoka@andela.com>"
+
+LABEL application="wirebot"
+
+ADD . /app
+
+WORKDIR /app
+
+RUN yarn install
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ start:
 	${INFO} "Starting local development server"
 	@ docker run wire-bot-image
 
+clean:
+	${INFO} "Cleaning your local environment"
+	${INFO} "Stopping the docker container"
+	@ docker stop `docker ps -qa -l`
+	${INFO} "Deleting the docker container"
+	@ docker rm `docker ps -qa -l`
+	${SUCCESS} "Done"
 
 # COLORS
 GREEN  := $(shell tput -Txterm setaf 2)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-PROJECT_NAME ?= wire-frontend
-
-DOCKER_DEV_COMPOSE_FILE := docker/dev/docker-compose.yml
+PROJECT_NAME ?= wire-bot
 
 .PHONY: help
 
@@ -52,9 +50,3 @@ INFO := @bash -c 'printf $(YELLOW); echo "===> $$1"; printf $(NC)' SOME_VALUE
 SUCCESS := @bash -c 'printf $(GREEN); echo "===> $$1"; printf $(NC)' SOME_VALUE
 # Shell Functions
 INFO := @bash -c ' printf $(YELLOW); echo "===> $$1";  printf $(NC)' SOME_VALUE
-
-# check and inspect Logic
-
-INSPECT := $$(docker-compose -p $$1 -f $$2 ps -q $$3 | xargs -I ARGS docker inspect -f "{{ .State.ExitCode }}" ARGS)
-
-CHECK := @bash -c 'if [[ $(INSPECT) -ne 0 ]]; then exit $(INSPECT); fi' VALUE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+PROJECT_NAME ?= wire-frontend
+
+DOCKER_DEV_COMPOSE_FILE := docker/dev/docker-compose.yml
+
+.PHONY: help
+
+## Show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '${YELLOW} make ${RESET} ${GREEN}<target> [options]${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@echo ''
+	@awk '/^[a-zA-Z\-\_0-9]+:/ { \
+		message = match(lastLine, /^## (.*)/); \
+		if (message) { \
+			command = substr($$1, 0, index($$1, ":")-1); \
+			message = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} %s\n", command, message; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	@echo ''
+	@echo ''
+
+## Start local development server
+start:
+	${INFO} "Building required docker images"
+	@ docker build -t wire-bot-image .
+	${INFO} "Build Completed successfully"
+	@ echo " "
+	${INFO} "Starting local development server"
+	@ docker run wire-bot-image
+
+
+# COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+NC := "\e[0m"
+RESET  := $(shell tput -Txterm sgr0)
+# Shell Functions
+INFO := @bash -c 'printf $(YELLOW); echo "===> $$1"; printf $(NC)' SOME_VALUE
+SUCCESS := @bash -c 'printf $(GREEN); echo "===> $$1"; printf $(NC)' SOME_VALUE
+# Shell Functions
+INFO := @bash -c ' printf $(YELLOW); echo "===> $$1";  printf $(NC)' SOME_VALUE
+
+# check and inspect Logic
+
+INSPECT := $$(docker-compose -p $$1 -f $$2 ps -q $$3 | xargs -I ARGS docker inspect -f "{{ .State.ExitCode }}" ARGS)
+
+CHECK := @bash -c 'if [[ $(INSPECT) -ne 0 ]]; then exit $(INSPECT); fi' VALUE

--- a/Makefile
+++ b/Makefile
@@ -24,20 +24,8 @@ help:
 
 ## Start local development server
 start:
-	${INFO} "Building required docker images"
-	@ docker build -t wire-bot-image .
-	${INFO} "Build Completed successfully"
-	@ echo " "
 	${INFO} "Starting local development server"
-	@ docker run wire-bot-image
-
-clean:
-	${INFO} "Cleaning your local environment"
-	${INFO} "Stopping the docker container"
-	@ docker stop `docker ps -qa -l`
-	${INFO} "Deleting the docker container"
-	@ docker rm `docker ps -qa -l`
-	${SUCCESS} "Done"
+	@ npm run start-dev
 
 # COLORS
 GREEN  := $(shell tput -Txterm setaf 2)


### PR DESCRIPTION
#### What does this PR do?
This PR  adds docker to wirebot to enable running the bot using docker containers. This will be later used to host the bot on Kubernetes.

#### Description of Task to be completed?
Setup docker workflow for Wirebot to enable running the bot with a single command : `make start`.
- [x] Create a Dockerfile.
- [x] Create a Makefile to enable running the app with` make start`.

#### Where should the reviewer start?
Review the changed files and test.

#### How should this be manually tested?
1. Clone the repo.
2. cd to `wire` directory.
3. Checkout to the `ch-setup-docker-for-development-environment` branch.
4. Set the environment variables in the `.env` file.
5. run `make start`
6. The sever should be listening on port 3000

#### What are the relevant pivotal tracker stories?
[#156956864](https://www.pivotaltracker.com/n/projects/2162441/stories/156956864)

