### PR TITLE
#157246114 Reduce Incident Description Minimum Length

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ slackEvents.on('message', event => {
       console.log('Logic flaw??'); // eslint-disable-line no-console
       break;
     case 4:
-      if (isDescriptionAdequate(event.text) === false) {
+      if (!isDescriptionAdequate(event.text)) {
         sc.chat.postMessage(
           event.channel,
           'Kindly add a bit more description of the incident',

--- a/modules/validation/description_validation.js
+++ b/modules/validation/description_validation.js
@@ -1,11 +1,5 @@
 const isDescriptionAdequate = entered_description => {
-  entered_description = entered_description.split(' ');
-
-  if (entered_description.length < 10) {
-    return false;
-  } else {
-    return true;
-  }
+  return entered_description.split(' ').length > 3;
 };
 
 module.exports = {


### PR DESCRIPTION
#### What does this PR do?
This PR reduces the `minimum required length` of an `incident's description` to `4 words long` when `validating`, from the previous `10 words long` as seen [here](https://github.com/AndelaOSP/wirebot/pull/7)

#### What are the relevant pivotal tracker stories?
[#157246114](https://www.pivotaltracker.com/n/projects/2117172/stories/157246114)