### PR TITLE
#157246271 Store and Append Incident Description

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,9 +164,27 @@ slackEvents.on('message', event => {
       break;
     case 4:
       if (!isDescriptionAdequate(event.text)) {
+        if (!actions.tempIncidents[userId].description) {
+          actions.tempIncidents[userId].description = event.text;
+        } else {
+          actions.tempIncidents[userId].description += ' ' + event.text;
+        }
+
+        if (isDescriptionAdequate(actions.tempIncidents[userId].description)) {
+          actions.tempIncidents[userId].step += 1;
+
+          sc.chat.postMessage(event.channel, '', witnessesMessage, err => {
+            if (err) {
+              logError(err);
+            }
+          });
+
+          break;
+        }
+
         sc.chat.postMessage(
           event.channel,
-          'Kindly add a bit more description of the incident',
+          'Kindly add a bit more description of the incident (Minimum: 4 words | simply add onto the above)',
           err => {
             if (err) {
               logError(err);

--- a/modules/actions.js
+++ b/modules/actions.js
@@ -53,7 +53,12 @@ const saveCategory = (payload, respond) => {
 const saveDescription = (event) => {
   const userId = event.user;
   const message = event.text;
-  tempIncidents[userId].description = message;
+  if (!tempIncidents[userId].description) {
+    tempIncidents[userId].description = message;
+  } else {
+    tempIncidents[userId].description += ' ' + message;
+  }
+  
   tempIncidents[userId].step += 1;
 };
 


### PR DESCRIPTION
#### What does this PR do?
This PR stores and appends an incident's description when the description's `minimum length validation fails`

#### Description of Task to be completed
Should the `minimum length validation fail`, the description already entered should be `stored` and any further description entered should be `appended` to the already stored description

#### How should this be tested?
When reporting an incident and requested to type in the incident's description:
- Enter a description that is less than `4 words long`
- The description entered will be `stored` and you will be requested to `add onto` this stored description
- You can test out different edge cases relating to this task

#### Any background context you want to add?
This will improve the end user's UX as they won't have to retype everything should the incident description's minimum length validation fail

#### Screenshots
<img width="739" alt="screen shot 2018-05-06 at 9 45 41 pm" src="https://user-images.githubusercontent.com/6702127/39676745-56fff2d0-5178-11e8-8705-1ee17370b979.png">

#### What are the relevant pivotal tracker stories?
[#157246271](https://www.pivotaltracker.com/n/projects/2117172/stories/157246271)