### PR TITLE
#157246196 Remove Comma When Tagging Witnesses

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ slackMessages.action('confirm', (payload, respond) => {
   let formatted_witnesses_promises = [];  
 
   if (incidentSummary.witnesses.length) { 
-    let witnesses = incidentSummary.witnesses.split(',');
+    let witnesses = incidentSummary.witnesses.split(' ');
     formatted_witnesses_promises = witnesses.map(witness => {
       let formatted_witness = witness.replace(/<|>|@/g, '').trim();
 
@@ -349,7 +349,7 @@ slackMessages.action('witnesses', (payload, respond) => {
     actions.saveWitnesses(event);
     confirmIncident(payload.user.id, payload.channel.id);
   } else {
-    respond({ text: 'Who are your witnesses? (@witness1, @witness2)' });
+    respond({ text: 'Who are your witnesses? (@witness1 @witness2)' });
   }
   return {
     text: 'Just a sec'

--- a/modules/validation/witnesses_validation.js
+++ b/modules/validation/witnesses_validation.js
@@ -1,5 +1,5 @@
 const isWitnessValid = entered_witnesses => {
-  let entered_witnesses_array = entered_witnesses.split(',');
+  let entered_witnesses_array = entered_witnesses.split(' ');
 
   let regex_test_result_array = [];
 


### PR DESCRIPTION
#### What does this PR do?
This PR removes the `comma requirement` when `tagging witnesses` in an incident report

#### Any background context you want to add?
This improves on the UX when tagging witnesses in an incident report, based on received feedback,  as users would forget the `comma requirement`

#### Screenshots
**Before**
<img width="417" alt="screen shot 2018-05-06 at 10 08 06 pm" src="https://user-images.githubusercontent.com/6702127/39676865-23cfd2de-517a-11e8-9bb3-07e12f677a7d.png">

**After**
<img width="396" alt="screen shot 2018-05-06 at 10 08 56 pm" src="https://user-images.githubusercontent.com/6702127/39676866-24002088-517a-11e8-9504-9d768e9ffa9d.png">

#### What are the relevant pivotal tracker stories?
[#157246196](https://www.pivotaltracker.com/n/projects/2117172/stories/157246196)