### PR TITLE
#157471943 New Incidents Trigger Slack Notification

### DIFF
--- a/modules/actions.js
+++ b/modules/actions.js
@@ -1,3 +1,6 @@
+const { categoryMessage } = require('./messages');
+const { logError } = require('./error_logger');
+
 const tempIncidents = {};
 
 const start = (payload, respond) => {
@@ -43,6 +46,26 @@ const saveLocation = (event) => {
 
 };
 
+const saveLocationHandler = (payload, respond) => {
+  const userId = payload.user.id;
+
+  switch(payload.actions[0].name) {
+  case 'select_location':
+    tempIncidents[userId].incidentHandler = payload.actions[0].selected_options[0].value;
+    break;
+  case 'submit':
+    if (!tempIncidents[userId].incidentHandler) {
+      break;
+    } else {
+      tempIncidents[userId].step += 1;
+      respond(categoryMessage).catch(error => {
+        logError(error);
+      });
+      break;
+    }
+  }
+};
+
 const saveCategory = (payload, respond) => {
   const userId = payload.user.id;
   tempIncidents[userId].category = payload.actions[0].value;
@@ -82,6 +105,7 @@ module.exports = {
   saveSubject,
   saveDate,
   saveLocation,
+  saveLocationHandler,
   saveCategory,
   saveDescription,
   saveIncident,

--- a/modules/incident_handler_verification.js
+++ b/modules/incident_handler_verification.js
@@ -1,0 +1,26 @@
+const incidentHandlerVerification = (incidentLocation) => {
+  const incidentCountry = incidentLocation.split(',')[2].trim().toUpperCase();
+
+  const countries = {
+    newYork: ['US', 'USA', 'UNITED STATES OF AMERICA', 'THE US', 'THE USA', 'AMERICA'],
+    kenya: ['KENYA', 'KE'],
+    nigeria: ['NIGERIA'],
+    uganda: ['UGANDA', 'UG']
+  };
+
+  if (countries.newYork.includes(incidentCountry)) {
+    return 'New York';
+  } else if (countries.kenya.includes(incidentCountry)) {
+    return 'Nairobi';
+  } else if (countries.nigeria.includes(incidentCountry)) {
+    return 'Lagos';
+  } else if (countries.uganda.includes(incidentCountry)) {
+    return 'Kampala';
+  } else {
+    return 'Elsewhere';
+  }
+};
+
+module.exports = {
+  incidentHandlerVerification
+};

--- a/modules/messages.js
+++ b/modules/messages.js
@@ -63,6 +63,49 @@ const getDateMessage = {
   text: 'When did the incident occur? (dd-mm-yy)'
 };
 
+const getLocationHandlerMessage = {
+  attachments: [
+    {
+      color: '#5A352D',
+      title: 'Where should this be handled',
+      callback_id: 'location_verifier',
+      actions: [
+        {
+          name: 'select_location',
+          text: 'Select Location...',
+          value: 'location',
+          type: 'select',
+          options: [
+            {
+              text: 'New York',
+              value: 'New York'
+            },
+            {
+              text: 'Lagos',
+              value: 'Lagos'
+            },
+            {
+              text: 'Nairobi',
+              value: 'Nairobi'
+            },
+            {
+              text: 'Kampala',
+              value: 'Kampala'
+            }
+          ]
+        },
+        {
+          name: 'submit',
+          text: 'Next',
+          type: 'button',
+          value: 'submit'
+        }
+      ]
+    
+    }
+  ]
+};
+
 const getConfirmationMessage = (data) =>
 {
   return {
@@ -151,6 +194,7 @@ const witnessesMessage = {
 module.exports = {
   initiationMessage: initiate,
   getDateMessage,
+  getLocationHandlerMessage,
   getConfirmationMessage,
   categoryMessage,
   witnessesMessage

--- a/modules/new_incident_notifier.js
+++ b/modules/new_incident_notifier.js
@@ -1,0 +1,86 @@
+const axios = require('axios');
+const dotenv = require('dotenv');
+const SlackClient = require('@slack/client').WebClient;
+
+dotenv.load();
+
+const sc = new SlackClient(process.env.SLACK_BOT_TOKEN);
+
+const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+const people_new_york = process.env.SLACK_PEOPLE_NEW_YORK;
+const people_lagos = process.env.SLACK_PEOPLE_LAGOS;
+const people_nairobi = process.env.SLACK_PEOPLE_NAIROBI;
+const people_kampala = process.env.SLACK_PEOPLE_KAMPALA;
+
+const getChannelNamePromise = (channelId) => {
+  return sc.groups.info(channelId)
+    .then(groupDetails => {
+      return groupDetails.group.name;
+    });
+};
+
+const postIncident = (incidentDetails) => {
+  return axios.post(slackWebhookUrl, {
+    'channel': `#${incidentDetails.channelName}`,
+    'username': 'wirebot',
+    'icon_emoji': ':robot_face:',
+    'attachments': [
+      {
+        'color': '#5A352D',
+        'pretext': 'New incident reported',
+        'fields': [
+          {
+            'title': 'Incident ID',
+            'value': `\`${incidentDetails.incidentId}\``
+          }
+        ]
+      }
+    ]
+  });
+};
+
+const newIncidentNotifier = (incident, incidentHandler) => {
+  if (incidentHandler === 'New York') {
+    return getChannelNamePromise(people_new_york).then(channelName => {
+      let incidentDetails = {
+        channelName,
+        incidentId: incident.id
+      };
+
+      return postIncident(incidentDetails);
+    });
+  } 
+  else if (incidentHandler === 'Nairobi') {
+    return getChannelNamePromise(people_nairobi).then(channelName => {
+      let incidentDetails = {
+        channelName,
+        incidentId: incident.id
+      };
+
+      return postIncident(incidentDetails);
+    });
+  } else if (incidentHandler === 'Lagos') {
+    return getChannelNamePromise(people_lagos).then(channelName => {
+      let incidentDetails = {
+        channelName,
+        incidentId: incident.id
+      };
+
+      return postIncident(incidentDetails);
+    });
+  } else {
+    return getChannelNamePromise(people_kampala).then(channelName => {
+      let incidentDetails = {
+        channelName,
+        incidentId: incident.id
+      };
+
+      return postIncident(incidentDetails);
+    });
+  }
+};
+
+module.exports = {
+  newIncidentNotifier
+};


### PR DESCRIPTION
#### What does this PR do?
This PR adds functionality to the bot to trigger Slack notifications to the repective P&C channel when a new incident is reported

#### Description of Task to be completed
Given a new incident has been reported:
- The bot will compare the `incident location` with a `predefined set of locations`
- If the incident location is present in the set of locations, the bot will post `a notification` on Slack to the `respective P&C channel` as shown below
<img width="361" alt="screen shot 2018-05-11 at 8 51 45 pm" src="https://user-images.githubusercontent.com/6702127/39938914-2e6d6878-555d-11e8-8215-6f70d65820ff.png">

- If the incident location isn't present in the set of locations, e.g. took place during travel, the bot will request the reporter to indicate the location where the incident should be handled, as shown below
<img width="338" alt="screen shot 2018-05-15 at 10 25 37 pm" src="https://user-images.githubusercontent.com/6702127/40080119-ba85fe46-5892-11e8-8045-cf9e3a5c5829.png">

#### How should this be tested?
When reporting an incident and requested to type in the location the incident took place:
- Enter a place, city and country
- Complete the process of reporting an incident and `submit`
- A notification will be sent to the respective channel

#### Any background context you want to add?
This will allow prompt response to a reported incident as the respective parties will be immediately notified when new incidents are reported

#### What are the relevant pivotal tracker stories?
[#157471943](https://www.pivotaltracker.com/n/projects/2117172/stories/157471943)