### PR TITLE
#157844100 Add Status Endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,6 +399,7 @@ cron.schedule('0 22 * * 1', function() {
 // Start a basic HTTP server
 const app = express();
 app.use(bodyParser.json());
+app.use('/status', (req, res) => res.status(200).send('Server up and running.'));
 app.use('/slack/events', slackEvents.expressMiddleware());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use('/slack/actions', slackMessages.expressMiddleware());


### PR DESCRIPTION
#### What does this PR do?
This PR adds a `/status` endpoint to the bot that returns a `HTTP status 200` indicating that it's up and running

#### Any background context you want to add?
This is a necessary addition for deploying the bot on Kubernetes, which needs at least an endpoint to indicate that it's running

#### What are the relevant pivotal tracker stories?
[#157844100](https://www.pivotaltracker.com/n/projects/2117172/stories/157844100)