### PR TITLE
#157962095 Hide Incident Confirmation Message

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,6 +266,10 @@ slackMessages.action('confirm', (payload, respond) => {
     return respond({'text': 'Ok, let me know if you change your mind :smiley:'});
   }
 
+  respond({
+    text: 'Just a sec'
+  });
+
   let incidentReporter = payload.user.id;
   let incidentSummary = actions.tempIncidents[incidentReporter];
   let location_array = incidentSummary.location.split(',');


### PR DESCRIPTION
#### What does this PR do?
This PR hides the `incident confirmation message` when the `Confirm` button is clicked

#### Description of Task to be Completed
When an incident reporter clicks the `Confirm` button:
- The `confirmation message` will be replaced with `Just a sec`

#### Any background context you want to add?
This improves on the UX by informing the incident reporter that the action they've selected, reporting the incident, is ongoing. 
It improves on the previous implementation whereby the reporter, unsure whether the selected action is successful or not, would click the `Confirm` button again, leading to duplication of incidents and their related data on the backend. 

#### What are the relevant pivotal tracker stories?
[#157962095](https://www.pivotaltracker.com/n/projects/2117172/stories/157962095)