### PR TITLE
#159926138 Remove Redundant Properties from CreatedIncident Object

### DIFF
--- a/modules/services.js
+++ b/modules/services.js
@@ -20,7 +20,7 @@ const { API_URL, PNC_CHANNELS } = process.env
  */
 function notifyPAndCChannels (payload) {
   try {
-    const { reporter: [{ location: { country } }] } = payload
+    const { reporter: [{ reporterLocation: { country } }] } = payload
     const channel = PNC_CHANNELS.split(',').find(
       value => value.toLowerCase().includes(country.toLowerCase())
     ).replace(`-${country.toLowerCase()}`, '')
@@ -41,7 +41,7 @@ function notifyPAndCChannels (payload) {
 function notifyWitnessesOnSlack (payload) {
   try {
     const { witnesses } = payload
-    const witnessIds = witnesses.map(value => value.id)
+    const witnessIds = witnesses.map(value => value.userId)
 
     return Promise.all(witnessIds.map(
       id => sendSlackMessage(id, '', witnessMessage(payload))
@@ -108,13 +108,11 @@ async function sendIncidentToWireApi (payload) {
     })
     // remove if wire api starts returning location instead of locationIds
     apiResult.reporter[0] = {
-      ...incidentReporter,
-      id: incidentReporter.userId,
-      location: incidentReporter.reporterLocation
+      ...incidentReporter
     }
     if (witnesses.length) {
       apiResult.witnesses = data.witnesses
-        .map(value => ({ ...value, id: value.userId }))
+        .map(value => ({ ...value }))
     }
 
     return apiResult

--- a/modules/slack/messages.js
+++ b/modules/slack/messages.js
@@ -301,7 +301,7 @@ function witnessMessage (incident) {
   const { Location: { name, centre, country }, dateOccurred } = incident
 
   return [{
-    pretext: `<@${incident.reporter[0].id}> reported an incident and tagged you\
+    pretext: `<@${incident.reporter[0].userId}> reported an incident and tagged you\
  as a witness`,
     color: color.primary,
     fields: [
@@ -329,7 +329,7 @@ function witnessMessage (incident) {
  * @returns {Object} slack attachment message
  */
 function pAndCMessage (incident) {
-  const { id, subject, reporter: [{ id: author }], levelId } = incident
+  const { id, subject, reporter: [{ userId: author }], levelId } = incident
 
   return [{
     pretext: 'New incident on Wire',


### PR DESCRIPTION
#### What does this PR do?
This PR refactors Wirebot code, removing redundant properties from the `createdIncident` object.

#### Description of Task to be completed
Once an incident has been created on the API side, the created incident object should not contain the redundant properties:
- `{ reporter: [{ location }] }` because `{ reporter: [{ reporterLocation }] }` already stores the same value.
- `{ witnesses: [{ id }] }` because `{ witnesses: [{ userId }] }` already stores the same value.

#### How should this be tested?
- Use the bot to report an incident
- Once the incident has been successfully created, Slack notifications should be successfully sent to the incident's `selected handler`, `reporter` and `witness(es)`.

#### Any background context you want to add?
The functionality of the bot should not be affected by these minor changes.

#### What are the relevant pivotal tracker stories?
[#159926138](https://www.pivotaltracker.com/n/projects/2117172/stories/159926138)