### PR TITLE
#160887623 Disable Witness Notifications

### DIFF
--- a/modules/slack/interactive_messages.js
+++ b/modules/slack/interactive_messages.js
@@ -133,8 +133,8 @@ function reportIncident (payload, respond) {
       .then((apiResponse) => {
         const { witnesses } = apiResponse
         respond(incidentSubmittedMessage(apiResponse))
-        Promise.all([
-          (witnesses && witnesses.length && notifyWitnessesOnSlack(apiResponse)),
+        // Uncomment the below commented out code to enable notifying tagged witnesses via Slack
+        Promise.all([/* (witnesses && witnesses.length && notifyWitnessesOnSlack(apiResponse)), */
           notifyPAndCChannels(apiResponse)
         ]).catch(logServiceError)
       })


### PR DESCRIPTION
#### What does this PR do?
This PR disables Slack notifications for `witnesses` tagged in an incident

#### Description of Task to be completed
When an incident that has witnesses is reported, the witnesses tagged in the report do not get notified via Slack of their being tagged in the incident

#### How should this be tested?
- Use the bot to report an incident that has at least one witness
- Once the incident has been successfully created, Slack notifications should be successfully sent to the incident's `selected handler` and `reporter`, but not to the `witness(es)`

#### Any background context you want to add?
This implements feedback received from the last sync with the stakeholders

#### What are the relevant pivotal tracker stories?
[#160887623](https://www.pivotaltracker.com/n/projects/2117172/stories/160887623)