### PR TITLE
chore(disable-witness-notifications): disable Slack notifications for…

### DIFF
--- a/modules/slack/interactive_messages.js
+++ b/modules/slack/interactive_messages.js
@@ -133,8 +133,8 @@ function reportIncident (payload, respond) {
       .then((apiResponse) => {
         const { witnesses } = apiResponse
         respond(incidentSubmittedMessage(apiResponse))
-        Promise.all([
-          (witnesses && witnesses.length && notifyWitnessesOnSlack(apiResponse)),
+        // Uncomment the below commented out code to enable notifying tagged witnesses via Slack
+        Promise.all([/* (witnesses && witnesses.length && notifyWitnessesOnSlack(apiResponse)), */
           notifyPAndCChannels(apiResponse)
         ]).catch(logServiceError)
       })


### PR DESCRIPTION
… tagged witnesses

- witnesses tagged in an incident report do not get notified via Slack

[Delivers: #160887623]