### PR TITLE
#158289469 Add ci badges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wirebot
+# wirebot [![Test Coverage](https://api.codeclimate.com/v1/badges/366efe7c8d9494bd82e8/test_coverage)](https://codeclimate.com/github/AndelaOSP/wirebot/test_coverage) [![CircleCI](https://circleci.com/gh/AndelaOSP/wirebot.svg?style=svg)](https://circleci.com/gh/AndelaOSP/wirebot)
 
 WIREBOT consumes [WIRE-API](https://github.com/AndelaOSP/wire-api)
 

--- a/modules/slack/interactive_messages.js
+++ b/modules/slack/interactive_messages.js
@@ -5,7 +5,7 @@ const { validateDate, validateLocation, logServiceError } = require('../utils')
 const {
   sendIncidentToWireApi,
   notifyPAndCChannels,
-  notifyWitnessesOnSlack
+  notifyWitnessesOnSlack // eslint-disable-line no-unused-vars
 } = require('../services')
 const {
   reportFormDialog,
@@ -131,6 +131,7 @@ function reportIncident (payload, respond) {
     respond(loadingMessage)
       .then(() => sendIncidentToWireApi(payload))
       .then((apiResponse) => {
+        // eslint-disable-next-line no-unused-vars
         const { witnesses } = apiResponse
         respond(incidentSubmittedMessage(apiResponse))
         // Uncomment the below commented out code to enable notifying tagged witnesses via Slack


### PR DESCRIPTION
#### What does this PR do?
This PR adds ci badges to the repository's `Readme`

#### Description of Task to be completed
When you navigate to the repository's Readme, `Codeclimate` and `Circle CI` test badges will be displayed

#### How should this be tested?
- Navigate to the repository's Readme
- A `Codeclimate test coverage badge` will be displayed
- A `Circle CI tests badge` will be displayed

#### Any background context you want to add?
This will help in knowing the test coverage of the codebase and also if the tests pass

#### Screenshots
<img width="548" alt="screen shot 2018-10-16 at 1 36 13 pm" src="https://user-images.githubusercontent.com/6702127/47011553-e84dd480-d14a-11e8-926c-ced7da0a833e.png">

#### What are the relevant pivotal tracker stories?
[#158289469](https://www.pivotaltracker.com/n/projects/2117172/stories/158289469)