### PR TITLE
#167648739 Fix reporting an incident with future date 

### DIFF
--- a/modules/slack/messages.js
+++ b/modules/slack/messages.js
@@ -63,7 +63,7 @@ const locationMessage = {
 const formErrorMessages = {
   dateError: {
     name: 'dateOccurred',
-    error: 'Sorry, this date is invalid!'
+    error: 'Sorry, this date is either invalid or a future date.'
   },
   locationError: {
     name: 'incidentLocation',

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -158,10 +158,10 @@ function formatUserData (slackUser, pAndCTeam) {
  * @returns {Boolean} validity of the date true or false
  */
 function validateDate (date) {
+  const currentDate = moment(new Date(), 'DD-MM-YYYY')
   const dateRegex = /^((0[1-9])|([12]\d)|(3[01]))-((0[1-9])|(1[0-2]))-\d{4}$/
 
-  return dateRegex.test(date) && moment(date, 'mm-dd-yyyy')
-    .isBefore(moment().add(1, 'day'))
+  return dateRegex.test(date) && moment(date, 'DD-MM-YYYY').isBefore(currentDate)
 }
 
 /**


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the bug that exist when reporting an incidence with future date

#### Description of Task to be completed
**Current Behavior** 
Currently when you report an incidence with a date after the present date it will create the incident.

**Expected Behavior**
Once you try reporting an incidence with a future date on slack it should not create the incidence.

#### How should this be tested?
Login to your slack channel.
Try reporting an incident with the /report command
Place a future date when reporting an incidence
Submit the report

#### Any background context you want to add?
N/A
#### What are the relevant pivotal tracker stories?
[#158290666](https://www.pivotaltracker.com/story/show/167648739)